### PR TITLE
Rodar docker localmente

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ ENV DATABASE_URL=postgresql://postgres:docker@postgres:5432/tech-challenger
 EXPOSE 3333
 
 # Exposição da porta para o Prisma Studio
-EXPOSE 5555
+EXPOSE 5557
 
 # Comando para criar banco de dados, iniciar a aplicação e o Prisma Studio
 CMD ["sh", "-c", "npx prisma generate && npx prisma db push && node dist/adapter/driver/server.js & npx prisma studio"]

--- a/Dockerfile.prisma-studio
+++ b/Dockerfile.prisma-studio
@@ -13,7 +13,7 @@ COPY prisma ./prisma
 RUN npm install
 
 # Expõe a porta padrão do Prisma Studio
-EXPOSE 5555
+EXPOSE 5557
 
 # Comando para iniciar o Prisma Studio
 CMD ["npx", "prisma", "studio"]

--- a/deploy/kubernetes/prisma-studio/prisma-deployment.yaml
+++ b/deploy/kubernetes/prisma-studio/prisma-deployment.yaml
@@ -20,7 +20,7 @@ spec:
           image: lucasaccurcio/tech-challenge-prisma-studio:v2
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 5555
+            - containerPort: 5557
           env:
             - name: POSTGRES_PASSWORD
               valueFrom:

--- a/deploy/kubernetes/prisma-studio/prisma-service.yaml
+++ b/deploy/kubernetes/prisma-studio/prisma-service.yaml
@@ -12,6 +12,6 @@ spec:
   ports:
     - name: prisma-studio-port
       protocol: TCP
-      port: 5555
-      targetPort: 5555
+      port: 5557
+      targetPort: 5557
       nodePort: 31555

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       dockerfile: Dockerfile
     ports:
       - '3333:3333'
-      - '5555:5555'
+      - '5557:5557'
     env_file: .env
     depends_on:
       mongo-init-replica:
@@ -70,7 +70,10 @@ services:
       API_PORT: 3333
     networks:
       - tech-challenge-payment-network
+      - tech-challenge-global
 
 networks:
   tech-challenge-payment-network:
     driver: bridge
+  tech-challenge-global:
+    external: true

--- a/src/adapter/driver/controllers/paymentOrderController.ts
+++ b/src/adapter/driver/controllers/paymentOrderController.ts
@@ -31,7 +31,9 @@ export class PaymentOrderController {
 			reply.code(StatusCodes.OK).send(paymentOrders);
 		} catch (error) {
 			const errorMessage = 'Unexpected error when listing for payment orders';
-			logger.error(`${errorMessage}: ${JSON.stringify(error)}`);
+			logger.error(
+				`${errorMessage}: ${JSON.stringify(error?.response.message)}`
+			);
 			handleError(req, reply, error);
 		}
 	}
@@ -49,17 +51,12 @@ export class PaymentOrderController {
 			const paymentOrder: PaymentOrder | null =
 				await this.paymentOrderService.getPaymentOrderById(params);
 
-			if (paymentOrder) {
-				reply.code(StatusCodes.OK).send(paymentOrder);
-			} else {
-				reply.code(StatusCodes.NOT_FOUND).send({
-					error: 'Not Found',
-					message: `Payment Order with ${params.id} not found`,
-				});
-			}
+			reply.code(StatusCodes.OK).send(paymentOrder);
 		} catch (error) {
 			const errorMessage = 'Unexpected error when listing for payment order';
-			logger.error(`${errorMessage}: ${JSON.stringify(error)}`);
+			logger.error(
+				`${errorMessage}: ${JSON.stringify(error?.response.message)}`
+			);
 			handleError(req, reply, error);
 		}
 	}
@@ -78,17 +75,12 @@ export class PaymentOrderController {
 			const paymentOrder: PaymentOrder | null =
 				await this.paymentOrderService.getPaymentOrderByOrderId(params);
 
-			if (paymentOrder) {
-				reply.code(StatusCodes.OK).send(paymentOrder);
-			} else {
-				reply.code(StatusCodes.NOT_FOUND).send({
-					error: 'Not Found',
-					message: `Payment Order with Order ID ${params.orderId} not found`,
-				});
-			}
+			reply.code(StatusCodes.OK).send(paymentOrder);
 		} catch (error) {
 			const errorMessage = 'Unexpected error when listing for payment order';
-			logger.error(`${errorMessage}: ${JSON.stringify(error)}`);
+			logger.error(
+				`${errorMessage}: ${JSON.stringify(error?.response.message)}`
+			);
 			handleError(req, reply, error);
 		}
 	}
@@ -109,7 +101,9 @@ export class PaymentOrderController {
 			reply.code(StatusCodes.OK).send(paymentOrder);
 		} catch (error) {
 			const errorMessage = 'Unexpected error when making payment order';
-			logger.error(`${errorMessage}: ${JSON.stringify(error)}`);
+			logger.error(
+				`${errorMessage}: ${JSON.stringify(error?.response.message)}`
+			);
 			handleError(req, reply, error);
 		}
 	}
@@ -127,7 +121,9 @@ export class PaymentOrderController {
 		} catch (error) {
 			const errorMessage =
 				'Unexpected error when process notification payment order';
-			logger.error(`${errorMessage}: ${JSON.stringify(error)}`);
+			logger.error(
+				`${errorMessage}: ${JSON.stringify(error?.response.message)}`
+			);
 			handleError(req, reply, error);
 		}
 	}

--- a/src/adapter/driver/routes/index.ts
+++ b/src/adapter/driver/routes/index.ts
@@ -46,31 +46,31 @@ const paymentOrderController = new PaymentOrderController(paymentOrderService);
 
 export const routes = async (fastify: FastifyInstance) => {
 	fastify.get(
-		'/payment-orders',
+		'/admin/payment-orders',
 		SwaggerGetPaymentOrders,
 		paymentOrderController.getPaymentOrders.bind(paymentOrderController)
 	);
 
 	fastify.get(
-		'/payment-orders/:id',
+		'/totem/payment-orders/:id',
 		SwaggerGetPaymentOrderById,
 		paymentOrderController.getPaymentOrderById.bind(paymentOrderController)
 	);
 
 	fastify.get(
-		'/payment-orders/orders/:orderId',
+		'/totem/payment-orders/orders/:orderId',
 		SwaggerGetPaymentOrderByOrderId,
 		paymentOrderController.getPaymentOrderByOrderId.bind(paymentOrderController)
 	);
 
 	fastify.post(
-		'/payment-orders/make-payment/:orderId',
+		'/totem/payment-orders/make-payment/:orderId',
 		SwaggerPaymentOrderMakePayment,
 		paymentOrderController.makePayment.bind(paymentOrderController)
 	);
 
 	fastify.post(
-		'/payment-orders/process-payment-notifications',
+		'/totem/payment-orders/process-payment-notifications',
 		SwaggerPaymentOrderProcessPaymentNotifications,
 		paymentOrderController.processPaymentNotification.bind(
 			paymentOrderController


### PR DESCRIPTION
- Alterar portas do prisma de 5555 para 5557 por questões de conflito;
- Adicionar `/totem` e `/admin` nas rotas;
- Adicionar `error.response.message` nas mensagens de erro para não estourar o backend;
- Remover 404 dos retornos, se não achar, apenas retorna vazio (estava quebrando o order, jogando pro catch)